### PR TITLE
Remove wayland and fallback x11 access

### DIFF
--- a/com.github.iwalton3.jellyfin-mpv-shim.json
+++ b/com.github.iwalton3.jellyfin-mpv-shim.json
@@ -6,8 +6,6 @@
   "command": "jellyfin-mpv-shim",
   "finish-args": [
     "--share=ipc",
-    "--socket=fallback-x11",
-    "--socket=wayland",
     "--device=all",
     "--share=network",
     "--socket=pulseaudio",


### PR DESCRIPTION
Remove access to wayland and disable x11 fallback because tkinter doesn't like wayland
Related to  jellyfin/jellyfin-mpv-shim#76
