### PR TITLE
Add access to the PipeWire socket

### DIFF
--- a/com.github.iwalton3.jellyfin-mpv-shim.json
+++ b/com.github.iwalton3.jellyfin-mpv-shim.json
@@ -10,7 +10,7 @@
     "--socket=wayland",
     "--device=all",
     "--share=network",
-    "--filesystem=xdg-run/pipewire-0",
+    "--filesystem=xdg-run/pipewire-0:ro",
     "--socket=pulseaudio",
     "--talk-name=org.gnome.SettingsDaemon.MediaKeys",
     "--env=LC_NUMERIC=C"

--- a/com.github.iwalton3.jellyfin-mpv-shim.json
+++ b/com.github.iwalton3.jellyfin-mpv-shim.json
@@ -10,6 +10,7 @@
     "--socket=wayland",
     "--device=all",
     "--share=network",
+    "--filesystem=xdg-run/pipewire-0",
     "--socket=pulseaudio",
     "--talk-name=org.gnome.SettingsDaemon.MediaKeys",
     "--env=LC_NUMERIC=C"


### PR DESCRIPTION
This allows MPV to directly use PipeWire.
This approach is described here: https://github.com/flatpak/flatpak/issues/5130#issuecomment-1272348665