### PR TITLE
Update GNOME runtime to 47, upate modules, use runtime ffmpeg

### DIFF
--- a/com.github.iwalton3.jellyfin-mpv-shim.json
+++ b/com.github.iwalton3.jellyfin-mpv-shim.json
@@ -1,9 +1,19 @@
 {
     "app-id": "com.github.iwalton3.jellyfin-mpv-shim",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "46",
+    "runtime-version": "47",
     "sdk": "org.gnome.Sdk",
     "command": "jellyfin-mpv-shim",
+    "add-extensions": {
+        "org.freedesktop.Platform.ffmpeg-full": {
+            "directory": "lib/ffmpeg",
+            "version": "24.08",
+            "add-ld-path": "."
+        }
+    },
+    "cleanup-commands": [
+        "mkdir -p /app/lib/ffmpeg"
+    ],  
     "finish-args": [
         "--share=ipc",
         "--socket=fallback-x11",
@@ -25,7 +35,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/iwalton3/tkinter-standalone",
-                    "commit": "d9cb97c5bd4f814c73678366e0e48220776b6ad3"
+                    "commit": "4f5cfe3cdd1f58cd4e136fd66d4e5e27d21d820b"
                 }
             ],
             "modules": [
@@ -34,8 +44,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://sourceforge.net/projects/tcl/files/Tcl/8.6.15/tcl8.6.15-src.tar.gz",
-                            "sha256": "861e159753f2e2fbd6ec1484103715b0be56be3357522b858d3cbb5f893ffef1",
+                            "url": "https://sourceforge.net/projects/tcl/files/Tcl/8.6.16/tcl8.6.16-src.tar.gz",
+                            "sha256": "91cb8fa61771c63c262efb553059b7c7ad6757afa5857af6265e4b0bdc2a14a5",
                             "x-checker-data": {
                                 "type": "html",
                                 "url": "https://sourceforge.net/projects/tcl/rss",
@@ -53,8 +63,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://sourceforge.net/projects/tcl/files/Tcl/8.6.15/tk8.6.15-src.tar.gz",
-                            "sha256": "550969f35379f952b3020f3ab7b9dd5bfd11c1ef7c9b7c6a75f5c49aca793fec",
+                            "url": "https://sourceforge.net/projects/tcl/files/Tcl/8.6.16/tk8.6.16-src.tar.gz",
+                            "sha256": "be9f94d3575d4b3099d84bc3c10de8994df2d7aa405208173c709cc404a7e5fe",
                             "x-checker-data": {
                                 "type": "html",
                                 "url": "https://sourceforge.net/projects/tcl/rss",
@@ -92,8 +102,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/mpv-player/mpv.git",
-                    "tag": "v0.38.0",
-                    "commit": "02254b92dd237f03aa0a151c2a68778c4ea848f9",
+                    "tag": "v0.39.0",
+                    "commit": "a0fba7be57f3822d967b04f0f6b6d6341e7516e7",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^v([\\d.]+)$"
@@ -147,9 +157,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://api.github.com/repos/sekrit-twc/zimg/tarball/release-3.0.4",
-                            "archive-type": "tar",
-                            "sha256": "c86b5a169b22c562172a11d83ce76a82dbdafc82149edcb8a06d0beeb94b193e"
+                            "url": "https://github.com/sekrit-twc/zimg/archive/refs/tags/release-3.0.5.tar.gz",
+                            "sha256": "a9a0226bf85e0d83c41a8ebe4e3e690e1348682f6a2a7838f1b8cbff1b799bcf"
                         }
                     ]
                 },
@@ -163,8 +172,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://breakfastquay.com/files/releases/rubberband-3.1.2.tar.bz2",
-                            "sha256": "dda7e257b14c59a1f59c5ccc4d6f19412039f77834275955aa0ff511779b98d2"
+                            "url": "https://breakfastquay.com/files/releases/rubberband-4.0.0.tar.bz2",
+                            "sha256": "af050313ee63bc18b35b2e064e5dce05b276aaf6d1aa2b8a82ced1fe2f8028e9"
                         }
                     ]
                 },
@@ -172,8 +181,7 @@
                     "name": "mujs",
                     "no-autogen": true,
                     "make-args": [
-                        "release",
-                        "shared"
+                        "release"
                     ],
                     "make-install-args": [
                         "prefix=/app",
@@ -188,8 +196,8 @@
                         {
                             "type": "git",
                             "url": "https://github.com/ccxvii/mujs.git",
-                            "tag": "1.3.2",
-                            "commit": "0e611cdc0c81a90dabfcb2ab96992acca95b886d"
+                            "tag": "1.3.5",
+                            "commit": "0df0707f2f10187127e36acfbc3ba9b9ca5b5cf0"
                         }
                     ]
                 },
@@ -203,8 +211,8 @@
                         {
                             "type": "git",
                             "url": "https://github.com/vapoursynth/vapoursynth.git",
-                            "tag": "R61",
-                            "commit": "35fe1e3b8b45553c6086c014645a9266388b43c6"
+                            "tag": "R70.11",
+                            "commit": "5657c20b62ec17faf7dd88e08de8500d2cb2aeab"
                         }
                     ]
                 },
@@ -224,41 +232,6 @@
                             "url": "https://github.com/FFmpeg/nv-codec-headers.git",
                             "tag": "n12.2.72.0",
                             "commit": "c69278340ab1d5559c7d7bf0edf615dc33ddbba7",
-                            "x-checker-data": {
-                                "type": "git",
-                                "tag-pattern": "^n([\\d.]+)$"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "name": "ffmpeg",
-                    "config-opts": [
-                        "--enable-shared",
-                        "--disable-static",
-                        "--enable-gnutls",
-                        "--enable-pic",
-                        "--disable-doc",
-                        "--disable-programs",
-                        "--disable-encoders",
-                        "--disable-muxers",
-                        "--disable-devices",
-                        "--enable-vaapi",
-                        "--enable-cuvid",
-                        "--enable-libdav1d",
-                        "--enable-gpl"
-                    ],
-                    "cleanup": [
-                        "/lib/pkgconfig",
-                        "/share",
-                        "/include"
-                    ],
-                    "sources": [
-                        {
-                            "type": "git",
-                            "url": "https://github.com/FFmpeg/FFmpeg.git",
-                            "tag": "n7.0.2",
-                            "commit": "e3a61e91030696348b56361bdf80ea358aef4a19",
                             "x-checker-data": {
                                 "type": "git",
                                 "tag-pattern": "^n([\\d.]+)$"
@@ -340,65 +313,6 @@
                                 "type": "git",
                                 "tag-pattern": "^v([\\d.]+)$"
                             }
-                        }
-                    ],
-                    "modules": [
-                        {
-                            "name": "shaderc",
-                            "buildsystem": "cmake-ninja",
-                            "builddir": true,
-                            "config-opts": [
-                                "-DSHADERC_SKIP_COPYRIGHT_CHECK=ON",
-                                "-DSHADERC_SKIP_EXAMPLES=ON",
-                                "-DSHADERC_SKIP_TESTS=ON",
-                                "-DSPIRV_SKIP_EXECUTABLES=ON",
-                                "-DENABLE_GLSLANG_BINARIES=OFF",
-                                "-DCMAKE_BUILD_TYPE=Release"
-                            ],
-                            "cleanup": [
-                                "/bin",
-                                "/include",
-                                "/lib/*.a",
-                                "/lib/cmake",
-                                "/lib/pkgconfig"
-                            ],
-                            "sources": [
-                                {
-                                    "type": "git",
-                                    "url": "https://github.com/google/shaderc.git",
-                                    "tag": "v2024.2",
-                                    "commit": "3ac03b8ad85a8e328a6182cddee8d05810bd5a2c",
-                                    "x-checker-data": {
-                                        "type": "git",
-                                        "tag-pattern": "^v([\\d.]+)$"
-                                    }
-                                },
-                                {
-                                    "type": "git",
-                                    "url": "https://github.com/KhronosGroup/SPIRV-Tools.git",
-                                    "tag": "v2023.2",
-                                    "commit": "44d72a9b36702f093dd20815561a56778b2d181e",
-                                    "dest": "third_party/spirv-tools"
-                                },
-                                {
-                                    "type": "git",
-                                    "url": "https://github.com/KhronosGroup/SPIRV-Headers.git",
-                                    "tag": "sdk-1.3.250.1",
-                                    "commit": "268a061764ee69f09a477a695bf6a11ffe311b8d",
-                                    "dest": "third_party/spirv-headers"
-                                },
-                                {
-                                    "type": "git",
-                                    "url": "https://github.com/KhronosGroup/glslang.git",
-                                    "tag": "14.3.0",
-                                    "commit": "fa9c3deb49e035a8abcabe366f26aac010f6cbfb",
-                                    "dest": "third_party/glslang",
-                                    "x-checker-data": {
-                                        "type": "git",
-                                        "tag-pattern": "^([\\d.]+)$"
-                                    }
-                                }
-                            ]
                         }
                     ]
                 }

--- a/pypi-dependencies.json
+++ b/pypi-dependencies.json
@@ -1,54 +1,39 @@
 {
-    "name": "python3-jellyfin-mpv-shim[all]",
+    "name": "python3-jellyfin-mpv-shim",
     "buildsystem": "simple",
     "build-commands": [
-        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} --no-build-isolation 'jellyfin-mpv-shim[all]'"
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"jellyfin-mpv-shim[all]\" --no-build-isolation"
     ],
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz",
-            "sha256": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+            "url": "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz",
+            "sha256": "ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/5a/84/44687a29792a70e111c5c477230a72c4b957d88d16141199bf9acb7537a3/websocket_client-1.8.0-py3-none-any.whl",
-            "sha256": "17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526"
+            "url": "https://files.pythonhosted.org/packages/7e/0a/a5260c758ff813acc6967344339aa7ba15f815575f4d49141685c4345d39/bottle-0.13.2-py2.py3-none-any.whl",
+            "sha256": "27569ab8d1332fbba3e400b3baab2227ab4efb4882ff147af05a7c00ed73409c"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/d5/0b/e7fc12c74dc9c60b272b07cc717eb4621f1b4d6b37f616204b815865bce4/pywebview-5.1.tar.gz",
-            "sha256": "87eb60c299de5f20269aa18588ca6dd0d79580df5adc6edf8ac1e184fbe4885c"
+            "url": "https://files.pythonhosted.org/packages/a5/32/8f6669fc4798494966bf446c8c4a162e0b5d893dff088afddf76414f70e1/certifi-2024.12.14-py3-none-any.whl",
+            "sha256": "1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/26/3d/b3599ab4ca816c174b682334e161dde920a646a5dbdaf030fd7bca19376a/python_mpv-1.0.6-py3-none-any.whl",
-            "sha256": "cdb3801ba122b28f37f3a019f265ee793500cd43b1d531c0ac1b7cb644d0c62a"
+            "url": "https://files.pythonhosted.org/packages/16/b0/572805e227f01586461c80e0fd25d65a2115599cc9dad142fee4b747c357/charset_normalizer-3.4.1.tar.gz",
+            "sha256": "44251f18cd68a75b56585dd00dae26183e102cd5e0f9f1466e6df5da2ed64ea3"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/6f/65/232563752a049831fdd6ae7b4caf8a557529d2f3c72ecbc40fb8b69e372c/python-mpv-jsonipc-1.2.0.tar.gz",
-            "sha256": "2199beefa6643d16483dda17c976bf2bbbf5dfedb1a5ca8d7d4611527ae6ad7a"
+            "url": "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl",
+            "sha256": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl",
-            "sha256": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/f2/cf/77d3e19b7fabd03895caca7857ef51e4c409e0ca6b37ee6e9f7daa50b642/proxy_tools-0.1.0.tar.gz",
-            "sha256": "ccb3751f529c047e2d8a58440d86b205303cf0fe8146f784d1cbcd94f0a28010"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/f4/2e/d110f862720b5e3ba1b0b719657385fc4151929befa2c6981f48360aa480/pypresence-4.3.0.tar.gz",
-            "sha256": "a6191a3af33a9667f2a4ef0185577c86b962ee70aa82643c472768a6fed1fbf3"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/86/f5/8c0653e5bb54e0cbdfe27bf32d41f27bc4e12faa8742778c17f2a71be2c0/python-xlib-0.33.tar.gz",
-            "sha256": "55af7906a2c75ce6cb280a584776080602444f75815a7aff4d287bb2d7018b32"
+            "url": "https://files.pythonhosted.org/packages/95/c8/8d8ed75cb0e829056e778c2ef942becbc6b11f5029ebb88ff7dd528eebeb/jellyfin_apiclient_python-1.10.0-py3-none-any.whl",
+            "sha256": "db7d1d2cce1261909a690420d93c346b296e3ecfc17ccf2ffc33f5880d408840"
         },
         {
             "type": "file",
@@ -57,103 +42,18 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/7a/50/7fd50a27caa0652cd4caf224aa87741ea41d3265ad13f010886167cfcc79/urllib3-2.2.1.tar.gz",
-            "sha256": "d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"
+            "url": "https://files.pythonhosted.org/packages/bd/0f/2ba5fbcd631e3e88689309dbe978c5769e883e4b84ebfe7da30b43275c5a/jinja2-3.1.5-py3-none-any.whl",
+            "sha256": "aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl",
-            "sha256": "70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"
+            "url": "https://files.pythonhosted.org/packages/f3/af/c097e544e7bd278333db77933e535098c259609c4eb3b85381109602fb5b/pillow-11.1.0.tar.gz",
+            "sha256": "368da70808b36d73b4b390a8ffac11069f8a5c85f29eff1f1b01bcf3ef5b2a20"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/9f/f7/b260e5bbf9b996adee1156125717656d415e38375ffe6828e1c48e2137ff/pywebview-5.1-py3-none-any.whl",
-            "sha256": "e352f587f82c173b28981fa0c893fab6124eb40d18c312e2bebf5346ab9f9f2c"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/87/5b/aae44c6655f3801e81aa3eef09dbbf012431987ba564d7231722f68df02d/MarkupSafe-2.1.5.tar.gz",
-            "sha256": "d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl",
-            "sha256": "bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl",
-            "sha256": "82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/3f/3e/5f9af21e2f7563d5444b3920110f0bce5678a31071e05ea56abb4cef9d02/python_mpv-1.0.6.tar.gz",
-            "sha256": "77e926f2ce569c5fc83d6531176e85e4c3249552f3059e818afb2f9cb33b9eeb"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz",
-            "sha256": "55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/fc/b8/ff33610932e0ee81ae7f1269c890f697d56ff74b9f5b2ee5d9b7fa2c5355/python_xlib-0.33-py2.py3-none-any.whl",
-            "sha256": "c3534038d42e0df2f1392a1b30a15a4ff5fdc2b86cfa94f072bf11b10a164398"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/e6/30/fba0d96b4b5fbf5948ed3f4681f7da2f9f64512e1d303f94b4cc174c24a5/websocket_client-1.8.0.tar.gz",
-            "sha256": "3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/ef/43/c50c17c5f7d438e836c169e343695534c38c77f60e7c90389bd77981bc21/pillow-10.3.0.tar.gz",
-            "sha256": "9d2455fbf44c914840c793e89aa82d0e1763a14253a000743719ae5946814b2d"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/21/ed/f86a79a07470cb07819390452f178b3bef1d375f2ec021ecfc709fc7cf07/idna-3.7.tar.gz",
-            "sha256": "028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/e8/fb/4217a963512b9646274fe4ce0aebc8ebff09bbb86c458c6163846bb65d9d/typing_extensions-4.12.1.tar.gz",
-            "sha256": "915f5e35ff76f56588223f15fdd5938f9a1cf9195c0de25130c627e4d597f6d1"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.whl",
-            "sha256": "450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/bb/1f/5977ea88c6a3df6199db97d320e5da816d415d1eb75a987a1f6823d5cc9d/bottle-0.12.25-py3-none-any.whl",
-            "sha256": "d6f15f9d422670b7c073d63bd8d287b135388da187a0f3e3c19293626ce034ea"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/ed/55/39036716d19cab0747a5020fc7e907f362fbf48c984b14e62127f7e68e5d/jinja2-3.1.4.tar.gz",
-            "sha256": "4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/11/e4/922108db0cc2814b34eca502bcd04a2776ae0a1f67c2ec1c69293ffc11c2/jellyfin-apiclient-python-1.9.2.tar.gz",
-            "sha256": "bcccd97a8896962dc78ccf03aabe5184d7d1ee07233eaa171b76ff68d365c764"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/07/b3/e02f4f397c81077ffc52a538e0aec464016f1860c472ed33bd2a1d220cc5/certifi-2024.6.2.tar.gz",
-            "sha256": "3cd43f1c6fa7dedc5899d69d3ad0398fd018ad1a17fba83ddaf78aa46c747516"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/fd/04/1c09ab851a52fe6bc063fd0df758504edede5cc741bd2e807bf434a09215/bottle-0.12.25.tar.gz",
-            "sha256": "e1a9c94970ae6d710b3fb4526294dfeb86f2cb4a81eff3a4b98dc40fb0e5e021"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz",
-            "sha256": "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"
+            "url": "https://files.pythonhosted.org/packages/f2/cf/77d3e19b7fabd03895caca7857ef51e4c409e0ca6b37ee6e9f7daa50b642/proxy_tools-0.1.0.tar.gz",
+            "sha256": "ccb3751f529c047e2d8a58440d86b205303cf0fe8146f784d1cbcd94f0a28010"
         },
         {
             "type": "file",
@@ -162,8 +62,13 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/aa/95/e596a8fe4925b1415181e117535aa3002cf236de06ae76b574d6531b79ea/pystray-0.19.4.tar.gz",
-            "sha256": "858784d4e969fe8b5bee6b5476432cf136e7087fdeaf4a1424b13f4f4de87155"
+            "url": "https://files.pythonhosted.org/packages/5c/64/927a4b9024196a4799eba0180e0ca31568426f258a4a5c90f87a97f51d28/pystray-0.19.5-py2.py3-none-any.whl",
+            "sha256": "a0c2229d02cf87207297c22d86ffc57c86c227517b038c0d3c59df79295ac617"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/76/b3/3c1d36719f819985211bb036460329e00a85e969e11b0abf183b969adbdb/python_mpv-1.0.7-py3-none-any.whl",
+            "sha256": "8546838b16abe6dc643832dabb84c4814c03f44cfb1d7f7dfda26ff79b9be236"
         },
         {
             "type": "file",
@@ -172,28 +77,33 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/b6/53/84a859aaddfe7378a6e5820e864a2d75763e82b6fcbda1a00e92ec620bb7/typing_extensions-4.12.1-py3-none-any.whl",
-            "sha256": "6024b58b69089e5a89c347397254e35f1bf02a907728ec7fee9bf0fe837d203a"
+            "url": "https://files.pythonhosted.org/packages/fc/b8/ff33610932e0ee81ae7f1269c890f697d56ff74b9f5b2ee5d9b7fa2c5355/python_xlib-0.33-py2.py3-none-any.whl",
+            "sha256": "c3534038d42e0df2f1392a1b30a15a4ff5fdc2b86cfa94f072bf11b10a164398"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/d3/49/4fff598d0e2d36c099613d5f7bd83e66530c3b24730afcea283f1d675db3/jellyfin_apiclient_python-1.9.2-py3-none-any.whl",
-            "sha256": "6a668ccee7b237d3029c66dc91c08e00e3ff1a2c363c0fc0ef177c1fa6f0cbe8"
+            "url": "https://files.pythonhosted.org/packages/b4/4f/fadb1eb352dbe8171dba983a7b8234af50e493b1a8aedb7fef902550019f/pywebview-5.3.2-py3-none-any.whl",
+            "sha256": "55f5a4bcfaa56738f2d6206977bd3d2864784249b0646c67e84f402ba1740000"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/17/93/5bb091943759d1c12747e599b47b440dfdd96e48f3d2e9edb3768ca0fcf0/jellyfin-mpv-shim-2.8.0.tar.gz",
-            "sha256": "10035a366bc3f2171d181d9aa067a62af03db324b556f22a1ac3f58e4d1bfa51"
+            "url": "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl",
+            "sha256": "70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/5b/11/1e78951465b4a225519b8c3ad29769c49e0d8d157a070f681d5b6d64737f/certifi-2024.6.2-py3-none-any.whl",
-            "sha256": "ddc6c8ce995e6987e7faf5e3f1b02b302836a0e5d98ece18392cb1a36c72ad56"
+            "url": "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl",
+            "sha256": "04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/5c/64/927a4b9024196a4799eba0180e0ca31568426f258a4a5c90f87a97f51d28/pystray-0.19.5-py2.py3-none-any.whl",
-            "sha256": "a0c2229d02cf87207297c22d86ffc57c86c227517b038c0d3c59df79295ac617"
+            "url": "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl",
+            "sha256": "1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/5a/84/44687a29792a70e111c5c477230a72c4b957d88d16141199bf9acb7537a3/websocket_client-1.8.0-py3-none-any.whl",
+            "sha256": "17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526"
         }
     ]
 }


### PR DESCRIPTION
`shaderc` is part of the runtime now and can be removed
Use ffmpeg from the runtime extension
Update various modules
Update python3 modules