### PR TITLE
Update permissions for pipewire & screen wake.

### DIFF
--- a/com.github.iwalton3.jellyfin-mpv-shim.json
+++ b/com.github.iwalton3.jellyfin-mpv-shim.json
@@ -11,7 +11,8 @@
         "--device=dri",
         "--share=network",
         "--socket=pulseaudio",
-        "--talk-name=org.gnome.SettingsDaemon.MediaKeys",
+        "--filesystem=xdg-run/pipewire-0:ro",
+        "--talk-name=org.gnome.SessionManager",
         "--env=LC_NUMERIC=C"
     ],
     "cleanup": [


### PR DESCRIPTION
- `--filesystem=xdg-run/pipewire-0:ro` closes #10
- `--talk-name=org.gnome.SessionManager` added to allow MPV to keep the screen awake per https://github.com/flathub/io.mpv.Mpv/blob/master/io.mpv.Mpv.yml#L27
- Removes `--talk-name=org.gnome.SettingsDaemon.MediaKeys` closing #12